### PR TITLE
Get all fees before removing shipping fees

### DIFF
--- a/edd-simple-shipping.php
+++ b/edd-simple-shipping.php
@@ -579,7 +579,7 @@ class EDD_Simple_Shipping {
 	 */
 	public function remove_shipping_fees() {
 
-		$fees = EDD()->fees->get_fees( 'fee' );
+		$fees = EDD()->fees->get_fees( 'all' );
 		if( empty( $fees ) ) {
 			return;
 		}


### PR DESCRIPTION
If you have added a fee as an 'item', Simple Shipping removes it from cart when a shipping charge is also present.